### PR TITLE
add a stateless (sessionId-less) version of ACK

### DIFF
--- a/app/src/main/java/com/github/bsideup/liiklus/service/ReactorLiiklusServiceImpl.java
+++ b/app/src/main/java/com/github/bsideup/liiklus/service/ReactorLiiklusServiceImpl.java
@@ -226,17 +226,31 @@ public class ReactorLiiklusServiceImpl extends ReactorLiiklusServiceGrpc.Liiklus
     public Mono<Empty> ack(Mono<AckRequest> request) {
         return request
                 .flatMap(ack -> {
-                    val subscription = subscriptions.get(ack.getAssignment().getSessionId());
+                    String topic;
+                    GroupId groupId;
+                    int partition;
 
-                    if (subscription == null) {
-                        log.warn("Subscription is null, returning empty Publisher. Request: {}", ack.toString().replace("\n", "\\n"));
-                        return Mono.empty();
+                    if (ack.hasAssignment()) {
+                        val subscription = subscriptions.get(ack.getAssignment().getSessionId());
+
+                        if (subscription == null) {
+                            log.warn("Subscription is null, returning empty Publisher. Request: {}", ack.toString().replace("\n", "\\n"));
+                            return Mono.empty();
+                        }
+
+                        topic = subscription.getTopic();
+                        groupId = subscription.getGroupId();
+                        partition = ack.getAssignment().getPartition();
+                    } else {
+                        topic = ack.getTopic();
+                        groupId = GroupId.of(ack.getGroup(), ack.getGroupVersion());
+                        partition = ack.getPartition();
                     }
 
                     return Mono.fromCompletionStage(positionsStorage.update(
-                            subscription.getTopic(),
-                            subscription.getGroupId(),
-                            ack.getAssignment().getPartition(),
+                            topic,
+                            groupId,
+                            partition,
                             ack.getOffset()
                     ));
                 })

--- a/app/src/test/java/com/github/bsideup/liiklus/AckTest.java
+++ b/app/src/test/java/com/github/bsideup/liiklus/AckTest.java
@@ -60,6 +60,36 @@ public class AckTest extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testStatelessAck() throws Exception {
+        int partition = 1;
+        int groupVersion = 1;
+        AckRequest ackRequest = AckRequest.newBuilder()
+                .setTopic(subscribeRequest.getTopic())
+                .setGroup(subscribeRequest.getGroup())
+                .setGroupVersion(groupVersion)
+                .setPartition(partition)
+                .setOffset(100)
+                .build();
+
+        stub.ack(ackRequest).block(Duration.ofSeconds(10));
+
+        Map<Integer, Long> positions = stub
+                .getOffsets(
+                        GetOffsetsRequest.newBuilder()
+                                .setTopic(subscribeRequest.getTopic())
+                                .setGroup(subscribeRequest.getGroup())
+                                .setGroupVersion(groupVersion)
+                                .build()
+                )
+                .map(GetOffsetsReply::getOffsetsMap)
+                .block(Duration.ofSeconds(10));
+
+        assertThat(positions)
+                .isNotNull()
+                .containsEntry(partition, 100L);
+    }
+
+    @Test
     public void testAlwaysLatest() throws Exception {
         Integer partition = stub.subscribe(subscribeRequest)
                 .map(SubscribeReply::getAssignment)

--- a/protocol/src/main/proto/LiiklusService.proto
+++ b/protocol/src/main/proto/LiiklusService.proto
@@ -76,7 +76,12 @@ message SubscribeReply {
 }
 
 message AckRequest {
-    Assignment assignment = 1;
+    Assignment assignment = 1 [deprecated=true];
+
+    string topic = 3;
+    string group = 4;
+    uint32 groupVersion = 5;
+    uint32 partition = 6;
 
     uint64 offset = 2;
 }


### PR DESCRIPTION
sessionId should only be used where it is needed, and ack call can be done without it, so I would rather remove it (also helps in scenarios when Liiklus being restarted)