### PR TITLE
Add grpc reflection service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile 'org.springframework.fu:spring-fu-autoconfigure-adapter'
 
     compile 'io.grpc:grpc-netty'
+    compile 'io.grpc:grpc-services'
     compile 'io.prometheus:simpleclient_common'
     compile 'org.pf4j:pf4j'
     compile 'io.rsocket:rsocket-transport-netty'

--- a/app/src/main/java/com/github/bsideup/liiklus/config/GRPCConfiguration.java
+++ b/app/src/main/java/com/github/bsideup/liiklus/config/GRPCConfiguration.java
@@ -4,6 +4,7 @@ import com.github.bsideup.liiklus.service.ReactorLiiklusServiceImpl;
 import io.grpc.*;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.netty.NettyServerBuilder;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.netty.channel.nio.NioEventLoopGroup;
 import lombok.Data;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -54,6 +55,7 @@ public class GRPCConfiguration implements ApplicationContextInitializer<GenericA
                                     return next.startCall(call, headers);
                                 }
                             })
+                            .addService(ProtoReflectionService.newInstance())
                             .addService(applicationContext.getBean(ReactorLiiklusServiceImpl.class))
                             .build();
                 },


### PR DESCRIPTION
User (and client services) can now inspect the metadata without
having to know the .proto definitions. E.g:

```
$ grpcurl -plaintext localhost:6565 describe
com.github.bsideup.liiklus.LiiklusService is a service:
service LiiklusService {
  rpc Ack ( .com.github.bsideup.liiklus.AckRequest ) returns ( .google.protobuf.Empty );
  rpc GetEndOffsets ( .com.github.bsideup.liiklus.GetEndOffsetsRequest ) returns ( .com.github.bsideup.liiklus.GetEndOffsetsReply );
  rpc GetOffsets ( .com.github.bsideup.liiklus.GetOffsetsRequest ) returns ( .com.github.bsideup.liiklus.GetOffsetsReply );
  rpc Publish ( .com.github.bsideup.liiklus.PublishRequest ) returns ( .com.github.bsideup.liiklus.PublishReply );
  rpc Receive ( .com.github.bsideup.liiklus.ReceiveRequest ) returns ( stream .com.github.bsideup.liiklus.ReceiveReply );
  rpc Subscribe ( .com.github.bsideup.liiklus.SubscribeRequest ) returns ( stream .com.github.bsideup.liiklus.SubscribeReply );
}
```