### PR TITLE
Fix pulsar intrinsic bugs

### DIFF
--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -1,10 +1,23 @@
 package com.github.bsideup.liiklus.pulsar;
 
 import com.github.bsideup.liiklus.records.FiniteRecordsStorage;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
 import lombok.experimental.FieldDefaults;
-import org.apache.pulsar.client.api.*;
-import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImplAccessor;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
@@ -14,11 +27,13 @@ import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -26,6 +41,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+@Slf4j
 @RequiredArgsConstructor
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PulsarRecordsStorage implements FiniteRecordsStorage {
@@ -40,6 +56,23 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
         // Use less than 32 bits to represent entry id since it will get
         // rolled over way before overflowing the max int range
         return (msgId.getLedgerId() << 28) | msgId.getEntryId();
+    }
+
+    // For closed ledger id, pulsar have a different treatment for entry id. It have to be lowered by 1.
+    // https://github.com/apache/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L2729
+    // https://github.com/apache/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L2744
+    private static MessageId adaptForSeek(MessageId messageId) {
+        MessageIdImpl id = (MessageIdImpl) messageId;
+        return new MessageIdImpl(id.getLedgerId(), Math.max(0, id.getEntryId() - 1), id.getPartitionIndex());
+    }
+
+    private static Instant extractTime(Message<byte[]> message) {
+        // event time does not always exist
+        if (message.getEventTime() == 0) {
+            return Instant.ofEpochMilli(message.getPublishTime());
+        } else {
+            return Instant.ofEpochMilli(message.getEventTime());
+        }
     }
 
     PulsarClient pulsarClient;
@@ -175,11 +208,46 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
 
         @Override
         public Publisher<Record> getPublisher() {
-            return Flux.using(
-                    () -> {
+            return Flux.usingWhen(createConsumer(), this::consumeMessage, this::cleanConsumer)
+                    .doOnSubscribe(__ -> log.debug(
+                            "pulsar-source: subscription {}, topic {}, partition {} subscribed",
+                            groupName, topic, partition
+                    ))
+                    .doOnComplete(() -> log.debug(
+                            "pulsar-source: subscription {}, topic {}, partition {} completed",
+                            groupName, topic, partition
+                    ))
+                    .onErrorMap(CompletionException.class, Throwable::getCause)
+                    .doOnError(
+                            e -> !(e instanceof PulsarClientException.ConsumerBusyException),
+                            e -> log.error(
+                                    "pulsar-source: subscription {}, topic {}, partition {} failed",
+                                    groupName, topic, partition, e
+                            )
+                    )
+                    .doOnError(
+                            e -> e instanceof PulsarClientException.ConsumerBusyException,
+                            e -> log.trace(
+                                    "pulsar-source: subscription {}, topic {}, partition {} already connected",
+                                    groupName, topic, partition
+                            )
+                    )
+                    // retry for connecting if the other exclusive pulsar consumer died
+                    // also need to retry as resetting subscription offset disconnect all pulsar consumers of a group
+                    // this should also be taken care of liiklus transparently for the liiklus consumer
+                    .retryBackoff(Long.MAX_VALUE, Duration.ofSeconds(1), Duration.ofSeconds(30));
+        }
+
+        private Mono<Consumer<byte[]>> createConsumer() {
+            return Mono
+                    .fromCompletionStage(() -> {
                         val consumerBuilder = pulsarClient.newConsumer()
                                 .subscriptionName(groupName)
-                                .subscriptionType(SubscriptionType.Failover)
+                                // failover subscription type does not failover properly
+                                // in case it works, unacked messaged will be re-delivered to other consumer
+                                // the only model which is compatible with liiklus is exclusive
+                                // which is similar to the reader interface of pulsar
+                                .subscriptionType(SubscriptionType.Exclusive)
                                 .topic(TopicName.get(topic).getPartition(partition).toString());
 
                         autoOffsetReset
@@ -196,42 +264,71 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
                                 .ifPresent(consumerBuilder::subscriptionInitialPosition);
 
                         return consumerBuilder.subscribeAsync();
-                    },
-                    future -> Mono
-                            .fromCompletionStage(future)
-                            .delayUntil(consumer -> {
-                                return initialOffset.delayUntil(offset -> {
-                                    return Mono.fromCompletionStage(consumer.seekAsync(fromOffset(offset)));
-                                });
-                            })
-                            .flatMapMany(consumer -> {
-                                return Mono
-                                        .fromCompletionStage(consumer::receiveAsync)
-                                        .repeat()
-                                        .onErrorResume(AlreadyClosedException.class, __ -> Mono.empty())
-                                        .map(message -> {
-                                            var key = message.getKey();
-                                            return new Record(
-                                                    new Envelope(
-                                                            topic,
-                                                            key != null ? ByteBuffer.wrap(key.getBytes()) : null,
-                                                            ByteBuffer.wrap(message.getValue())
-                                                    ),
-                                                    Instant.ofEpochMilli(message.getEventTime()),
-                                                    partition,
-                                                    toOffset(message.getMessageId())
-                                            );
-                                        });
-                            }),
-                    it -> {
-                        if (it.isDone()) {
-                            Consumer<byte[]> consumer = it.getNow(null);
-                            if (consumer != null && consumer.isConnected()) {
-                                consumer.closeAsync();
-                            }
-                        }
-                    }
-            );
+                    })
+                    .doOnNext(__ -> log.debug(
+                            "consumer-creation: subscription {}, topic {}, partition {} success",
+                            groupName, topic, partition
+                    ))
+                    .onErrorMap(CompletionException.class, Throwable::getCause)
+                    .doOnError(
+                            e -> !(e instanceof PulsarClientException.ConsumerBusyException),
+                            e -> log.error(
+                                    "consumer-creation: subscription {}, topic {}, partition {} failed",
+                                    groupName, topic, partition, e
+                            )
+                    )
+                    .doOnError(
+                            e -> e instanceof PulsarClientException.ConsumerBusyException,
+                            e -> log.trace(
+                                    "consumer-creation: subscription {}, topic {}, partition {} already connected",
+                                    groupName, topic, partition
+                            )
+                    );
+        }
+
+        private Flux<Record> consumeMessage(Consumer<byte[]> consumer) {
+            return Mono
+                    .fromCompletionStage(consumer::receiveAsync)
+                    .repeat()
+                    .map(message -> {
+                        var key = message.getKey();
+                        return new Record(
+                                new Envelope(
+                                        topic,
+                                        key != null ? ByteBuffer.wrap(key.getBytes()) : null,
+                                        ByteBuffer.wrap(message.getValue())
+                                ),
+                                extractTime(message),
+                                partition,
+                                toOffset(message.getMessageId())
+                        );
+                    })
+                    .delaySubscription(initialOffset.flatMap(offset -> resetSubscriptionOffset(consumer, offset)));
+        }
+
+        private Mono<Void> resetSubscriptionOffset(Consumer<byte[]> consumer, Long offset) {
+            return Mono.fromCompletionStage(consumer.seekAsync(adaptForSeek(fromOffset(offset))))
+                    .doOnSuccess(__ -> log.debug(
+                            "reset-subscription: subscription {}, topic {}, partition {} is reset to {}",
+                            groupName, topic, partition, offset
+                    ))
+                    .doOnError(e -> log.debug(
+                            "reset-subscription: subscription {}, topic {}, partition {} reset to {} failed",
+                            groupName, topic, partition, offset, e
+                    ));
+        }
+
+        private Mono<Void> cleanConsumer(Consumer<byte[]> consumer) {
+            return Mono.fromCompletionStage(consumer.closeAsync())
+                    .doOnSuccess(__ -> log.debug(
+                            "clean-consumer: subscription {}, topic {}, partition {} cleanup succeed",
+                            groupName, topic, partition
+                    ))
+                    .doOnError(e -> log.debug(
+                            "clean-consumer: subscription {}, topic {}, partition {} cleanup failed",
+                            groupName, topic, partition, e
+                    ));
         }
     }
+
 }

--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -210,25 +210,25 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
         public Publisher<Record> getPublisher() {
             return Flux.usingWhen(createConsumer(), this::consumeMessage, this::cleanConsumer)
                     .doOnSubscribe(__ -> log.debug(
-                            "pulsar-source: subscription {}, topic {}, partition {} subscribed",
+                            "subscription {}, topic {}, partition {} subscribed",
                             groupName, topic, partition
                     ))
                     .doOnComplete(() -> log.debug(
-                            "pulsar-source: subscription {}, topic {}, partition {} completed",
+                            "subscription {}, topic {}, partition {} completed",
                             groupName, topic, partition
                     ))
                     .onErrorMap(CompletionException.class, Throwable::getCause)
                     .doOnError(
                             e -> !(e instanceof PulsarClientException.ConsumerBusyException),
                             e -> log.error(
-                                    "pulsar-source: subscription {}, topic {}, partition {} failed",
+                                    "subscription {}, topic {}, partition {} failed",
                                     groupName, topic, partition, e
                             )
                     )
                     .doOnError(
                             e -> e instanceof PulsarClientException.ConsumerBusyException,
                             e -> log.trace(
-                                    "pulsar-source: subscription {}, topic {}, partition {} already connected",
+                                    "subscription {}, topic {}, partition {} already connected",
                                     groupName, topic, partition
                             )
                     )
@@ -266,21 +266,21 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
                         return consumerBuilder.subscribeAsync();
                     })
                     .doOnNext(__ -> log.debug(
-                            "consumer-creation: subscription {}, topic {}, partition {} success",
+                            "subscription {}, topic {}, partition {} consumer created",
                             groupName, topic, partition
                     ))
                     .onErrorMap(CompletionException.class, Throwable::getCause)
                     .doOnError(
                             e -> !(e instanceof PulsarClientException.ConsumerBusyException),
                             e -> log.error(
-                                    "consumer-creation: subscription {}, topic {}, partition {} failed",
+                                    "subscription {}, topic {}, partition {} failed to create consumer",
                                     groupName, topic, partition, e
                             )
                     )
                     .doOnError(
                             e -> e instanceof PulsarClientException.ConsumerBusyException,
                             e -> log.trace(
-                                    "consumer-creation: subscription {}, topic {}, partition {} already connected",
+                                    "subscription {}, topic {}, partition {} already connected",
                                     groupName, topic, partition
                             )
                     );
@@ -309,11 +309,11 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
         private Mono<Void> resetSubscriptionOffset(Consumer<byte[]> consumer, Long offset) {
             return Mono.fromCompletionStage(consumer.seekAsync(adaptForSeek(fromOffset(offset))))
                     .doOnSuccess(__ -> log.debug(
-                            "reset-subscription: subscription {}, topic {}, partition {} is reset to {}",
+                            "subscription {}, topic {}, partition {} is reset to {}",
                             groupName, topic, partition, offset
                     ))
                     .doOnError(e -> log.debug(
-                            "reset-subscription: subscription {}, topic {}, partition {} reset to {} failed",
+                            "subscription {}, topic {}, partition {} reset to {} failed",
                             groupName, topic, partition, offset, e
                     ));
         }
@@ -321,11 +321,11 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
         private Mono<Void> cleanConsumer(Consumer<byte[]> consumer) {
             return Mono.fromCompletionStage(consumer::closeAsync)
                     .doOnSuccess(__ -> log.debug(
-                            "clean-consumer: subscription {}, topic {}, partition {} cleanup succeed",
+                            "subscription {}, topic {}, partition {} cleanup succeed",
                             groupName, topic, partition
                     ))
                     .doOnError(e -> log.debug(
-                            "clean-consumer: subscription {}, topic {}, partition {} cleanup failed",
+                            "subscription {}, topic {}, partition {} cleanup failed",
                             groupName, topic, partition, e
                     ));
         }

--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -319,7 +319,7 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
         }
 
         private Mono<Void> cleanConsumer(Consumer<byte[]> consumer) {
-            return Mono.fromCompletionStage(consumer.closeAsync())
+            return Mono.fromCompletionStage(consumer::closeAsync)
                     .doOnSuccess(__ -> log.debug(
                             "clean-consumer: subscription {}, topic {}, partition {} cleanup succeed",
                             groupName, topic, partition

--- a/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
+++ b/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
@@ -6,16 +6,37 @@ import com.github.bsideup.liiklus.records.RecordsStorage;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.Murmur3_32Hash;
 import org.apache.pulsar.client.util.MathUtils;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.testcontainers.containers.PulsarContainer;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.ReplayProcessor;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PulsarRecordsStorageTest implements RecordStorageTests {
 
@@ -69,5 +90,213 @@ public class PulsarRecordsStorageTest implements RecordStorageTests {
     @Override
     public int getNumberOfPartitions() {
         return NUM_OF_PARTITIONS;
+    }
+
+    @Test
+    @Override
+    // since pulsar behave differently for closed ledger, need to overwrite this test to include the 1 entry setback
+    public void testInitialOffsets() throws Exception {
+        var offsetInfos = publishMany("key".getBytes(), 10);
+        var offsetInfo = offsetInfos.get(7);
+        var partition = offsetInfo.getPartition();
+        var position = offsetInfo.getOffset();
+
+        var receivedRecords = subscribeToPartition(partition, Optional.of("earliest"), () -> CompletableFuture.completedFuture(Collections.singletonMap(partition, position)))
+                .flatMap(RecordsStorage.PartitionSource::getPublisher)
+                .take(4)
+                .collectList()
+                .block(Duration.ofSeconds(10));
+
+        assertThat(receivedRecords).extracting(RecordsStorage.Record::getOffset).containsExactly(
+                offsetInfos.get(6).getOffset(),
+                offsetInfos.get(7).getOffset(),
+                offsetInfos.get(8).getOffset(),
+                offsetInfos.get(9).getOffset()
+        );
+    }
+
+    @Test
+    @Override
+    // currently each liiklus consumers consume all partition, and leaves the client to rebalance
+    // in pulsar, the pulsar client does not rebalance naturally on failover or exclusive
+    public void testExclusiveRecordDistribution() throws Exception {
+        var numberOfPartitions = getNumberOfPartitions();
+        Assumptions.assumeTrue(numberOfPartitions > 1, "target supports more than 1 partition");
+
+        var groupName = UUID.randomUUID().toString();
+
+        var receivedOffsets = new ConcurrentHashMap<RecordsStorage.Subscription, Set<Tuple2<Integer, Long>>>();
+
+        var disposeAll = ReplayProcessor.<Boolean>create(1);
+
+        Function<RecordsStorage.Subscription, Disposable> subscribeAndAssign = subscription -> {
+            return Flux.from(subscription.getPublisher(() -> CompletableFuture.completedFuture(Collections.emptyMap())))
+                    .flatMap(Flux::fromStream, numberOfPartitions)
+                    .flatMap(RecordsStorage.PartitionSource::getPublisher, numberOfPartitions)
+                    .takeUntilOther(disposeAll)
+                    .subscribe(record -> {
+                        receivedOffsets
+                                .computeIfAbsent(subscription, __ -> new HashSet<>())
+                                .add(Tuples.of(record.getPartition(), record.getOffset()));
+                    });
+        };
+
+        try {
+            var firstSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("earliest"));
+            var secondSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("earliest"));
+
+            subscribeAndAssign.apply(firstSubscription);
+            await.untilAsserted(() -> {
+                try {
+                    assertThat(receivedOffsets)
+                            .containsKeys(firstSubscription)
+                            .doesNotContainKey(secondSubscription)
+                            .allSatisfy((key, value) -> assertThat(value).isNotEmpty());
+                } catch (Throwable e) {
+                    publishToEveryPartition();
+                    throw e;
+                }
+            });
+
+            subscribeAndAssign.apply(secondSubscription);
+            publishToEveryPartition();
+
+            await.pollDelay(org.awaitility.Duration.TWO_SECONDS).untilAsserted(() -> {
+                try {
+                    assertThat(receivedOffsets)
+                            .containsKeys(firstSubscription)
+                            .doesNotContainKey(secondSubscription)
+                            .allSatisfy((key, value) -> assertThat(value).isNotEmpty());
+                } catch (Throwable e) {
+                    publishToEveryPartition();
+                    throw e;
+                }
+            });
+        } finally {
+            disposeAll.onNext(true);
+        }
+    }
+
+    @Test
+    @Override
+    // currently each liiklus consumers consume all partition, and leaves the client to rebalance
+    // in pulsar, the pulsar client does not rebalance naturally on failover or exclusive
+    public void testMultipleGroups() throws Exception {
+        var numberOfPartitions = getNumberOfPartitions();
+        Assumptions.assumeTrue(numberOfPartitions > 1, "target supports more than 1 partition");
+
+        var groupName = UUID.randomUUID().toString();
+
+        var receivedOffsets = new HashMap<RecordsStorage.Subscription, Map<Integer, Long>>();
+
+        var disposeAll = ReplayProcessor.<Boolean>create(1);
+
+        Function<RecordsStorage.Subscription, Disposable> subscribeAndAssign = subscription -> {
+            return Flux.from(subscription.getPublisher(() -> CompletableFuture.completedFuture(Collections.emptyMap())))
+                    .flatMap(Flux::fromStream, numberOfPartitions)
+                    .flatMap(RecordsStorage.PartitionSource::getPublisher, numberOfPartitions)
+                    .takeUntilOther(disposeAll)
+                    .subscribe(record -> {
+                        receivedOffsets
+                                .computeIfAbsent(subscription, __ -> new HashMap<>())
+                                .put(record.getPartition(), record.getOffset());
+                    });
+        };
+
+        try {
+            var firstSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("latest"));
+            var secondSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("latest"));
+            var lastOffsets = new HashMap<Integer, Long>();
+
+            var firstDisposable = subscribeAndAssign.apply(firstSubscription);
+            await.untilAsserted(() -> {
+                try {
+                    assertThat(receivedOffsets).hasEntrySatisfying(firstSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
+                    assertThat(receivedOffsets).doesNotContainKey(secondSubscription);
+                } catch (Throwable e) {
+                    lastOffsets.putAll(publishToEveryPartition());
+                    throw e;
+                }
+            });
+            receivedOffsets.clear();
+
+            var secondDisposable = subscribeAndAssign.apply(secondSubscription);
+            await.untilAsserted(() -> {
+                try {
+                    assertThat(receivedOffsets).hasEntrySatisfying(firstSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
+                    assertThat(receivedOffsets).doesNotContainKey(secondSubscription);
+                } catch (Throwable e) {
+                    lastOffsets.putAll(publishToEveryPartition());
+                    throw e;
+                }
+            });
+            receivedOffsets.clear();
+
+            firstDisposable.dispose();
+            await.untilAsserted(() -> {
+                try {
+                    assertThat(receivedOffsets).doesNotContainKey(firstSubscription);
+                    assertThat(receivedOffsets).hasEntrySatisfying(secondSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
+                } catch (Throwable e) {
+                    lastOffsets.putAll(publishToEveryPartition());
+                    throw e;
+                }
+            });
+            receivedOffsets.clear();
+
+            subscribeAndAssign.apply(firstSubscription);
+            secondDisposable.dispose();
+            await.untilAsserted(() -> {
+                try {
+                    assertThat(receivedOffsets).hasEntrySatisfying(firstSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
+                    assertThat(receivedOffsets).doesNotContainKey(secondSubscription);
+                } catch (Throwable e) {
+                    lastOffsets.putAll(publishToEveryPartition());
+                    throw e;
+                }
+            });
+        } finally {
+            disposeAll.onNext(true);
+        }
+    }
+
+    @Test
+    void testEventTimestampPreference() throws Exception {
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl(pulsar.getPulsarBrokerUrl())
+                .build();
+
+        byte[] key = UUID.randomUUID().toString().getBytes();
+        Instant eventTimestamp = Instant.now().minusSeconds(1000).truncatedTo(ChronoUnit.MILLIS);
+
+        pulsarClient.newProducer()
+                .topic(topic)
+                .hashingScheme(HashingScheme.Murmur3_32Hash)
+                .enableBatching(false)
+                .create()
+                .newMessage()
+                .keyBytes(key)
+                .value("hello".getBytes())
+                .eventTime(eventTimestamp.toEpochMilli())
+                .send();
+
+        var topic = getTopic();
+        var offsetInfo = publish(new RecordsStorage.Envelope(
+                topic,
+                ByteBuffer.wrap(key),
+                ByteBuffer.wrap("hello".getBytes())
+        ));
+        int partition = offsetInfo.getPartition();
+
+        var records = subscribeToPartition(partition)
+                .flatMap(RecordsStorage.PartitionSource::getPublisher)
+                .take(2)
+                .collectList()
+                .block(Duration.ofSeconds(10));
+
+        assertThat(records)
+                .hasSize(2)
+                .anySatisfy(it -> assertThat(it.getTimestamp()).isEqualTo(eventTimestamp))
+                .anySatisfy(it -> assertThat(it.getTimestamp()).isAfter(eventTimestamp));
     }
 }

--- a/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
+++ b/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
@@ -11,30 +11,17 @@ import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.Murmur3_32Hash;
 import org.apache.pulsar.client.util.MathUtils;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.testcontainers.containers.PulsarContainer;
-import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.ReplayProcessor;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -90,174 +77,6 @@ public class PulsarRecordsStorageTest implements RecordStorageTests {
     @Override
     public int getNumberOfPartitions() {
         return NUM_OF_PARTITIONS;
-    }
-
-    @Test
-    @Override
-    // since pulsar behave differently for closed ledger, need to overwrite this test to include the 1 entry setback
-    public void testInitialOffsets() throws Exception {
-        var offsetInfos = publishMany("key".getBytes(), 10);
-        var offsetInfo = offsetInfos.get(7);
-        var partition = offsetInfo.getPartition();
-        var position = offsetInfo.getOffset();
-
-        var receivedRecords = subscribeToPartition(partition, Optional.of("earliest"), () -> CompletableFuture.completedFuture(Collections.singletonMap(partition, position)))
-                .flatMap(RecordsStorage.PartitionSource::getPublisher)
-                .take(4)
-                .collectList()
-                .block(Duration.ofSeconds(10));
-
-        assertThat(receivedRecords).extracting(RecordsStorage.Record::getOffset).containsExactly(
-                offsetInfos.get(6).getOffset(),
-                offsetInfos.get(7).getOffset(),
-                offsetInfos.get(8).getOffset(),
-                offsetInfos.get(9).getOffset()
-        );
-    }
-
-    @Test
-    @Override
-    // currently each liiklus consumers consume all partition, and leaves the client to rebalance
-    // in pulsar, the pulsar client does not rebalance naturally on failover or exclusive
-    public void testExclusiveRecordDistribution() throws Exception {
-        var numberOfPartitions = getNumberOfPartitions();
-        Assumptions.assumeTrue(numberOfPartitions > 1, "target supports more than 1 partition");
-
-        var groupName = UUID.randomUUID().toString();
-
-        var receivedOffsets = new ConcurrentHashMap<RecordsStorage.Subscription, Set<Tuple2<Integer, Long>>>();
-
-        var disposeAll = ReplayProcessor.<Boolean>create(1);
-
-        Function<RecordsStorage.Subscription, Disposable> subscribeAndAssign = subscription -> {
-            return Flux.from(subscription.getPublisher(() -> CompletableFuture.completedFuture(Collections.emptyMap())))
-                    .flatMap(Flux::fromStream, numberOfPartitions)
-                    .flatMap(RecordsStorage.PartitionSource::getPublisher, numberOfPartitions)
-                    .takeUntilOther(disposeAll)
-                    .subscribe(record -> {
-                        receivedOffsets
-                                .computeIfAbsent(subscription, __ -> new HashSet<>())
-                                .add(Tuples.of(record.getPartition(), record.getOffset()));
-                    });
-        };
-
-        try {
-            var firstSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("earliest"));
-            var secondSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("earliest"));
-
-            subscribeAndAssign.apply(firstSubscription);
-            await.untilAsserted(() -> {
-                try {
-                    assertThat(receivedOffsets)
-                            .containsKeys(firstSubscription)
-                            .doesNotContainKey(secondSubscription)
-                            .allSatisfy((key, value) -> assertThat(value).isNotEmpty());
-                } catch (Throwable e) {
-                    publishToEveryPartition();
-                    throw e;
-                }
-            });
-
-            subscribeAndAssign.apply(secondSubscription);
-            publishToEveryPartition();
-
-            await.pollDelay(org.awaitility.Duration.TWO_SECONDS).untilAsserted(() -> {
-                try {
-                    assertThat(receivedOffsets)
-                            .containsKeys(firstSubscription)
-                            .doesNotContainKey(secondSubscription)
-                            .allSatisfy((key, value) -> assertThat(value).isNotEmpty());
-                } catch (Throwable e) {
-                    publishToEveryPartition();
-                    throw e;
-                }
-            });
-        } finally {
-            disposeAll.onNext(true);
-        }
-    }
-
-    @Test
-    @Override
-    // currently each liiklus consumers consume all partition, and leaves the client to rebalance
-    // in pulsar, the pulsar client does not rebalance naturally on failover or exclusive
-    public void testMultipleGroups() throws Exception {
-        var numberOfPartitions = getNumberOfPartitions();
-        Assumptions.assumeTrue(numberOfPartitions > 1, "target supports more than 1 partition");
-
-        var groupName = UUID.randomUUID().toString();
-
-        var receivedOffsets = new HashMap<RecordsStorage.Subscription, Map<Integer, Long>>();
-
-        var disposeAll = ReplayProcessor.<Boolean>create(1);
-
-        Function<RecordsStorage.Subscription, Disposable> subscribeAndAssign = subscription -> {
-            return Flux.from(subscription.getPublisher(() -> CompletableFuture.completedFuture(Collections.emptyMap())))
-                    .flatMap(Flux::fromStream, numberOfPartitions)
-                    .flatMap(RecordsStorage.PartitionSource::getPublisher, numberOfPartitions)
-                    .takeUntilOther(disposeAll)
-                    .subscribe(record -> {
-                        receivedOffsets
-                                .computeIfAbsent(subscription, __ -> new HashMap<>())
-                                .put(record.getPartition(), record.getOffset());
-                    });
-        };
-
-        try {
-            var firstSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("latest"));
-            var secondSubscription = getTarget().subscribe(getTopic(), groupName, Optional.of("latest"));
-            var lastOffsets = new HashMap<Integer, Long>();
-
-            var firstDisposable = subscribeAndAssign.apply(firstSubscription);
-            await.untilAsserted(() -> {
-                try {
-                    assertThat(receivedOffsets).hasEntrySatisfying(firstSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
-                    assertThat(receivedOffsets).doesNotContainKey(secondSubscription);
-                } catch (Throwable e) {
-                    lastOffsets.putAll(publishToEveryPartition());
-                    throw e;
-                }
-            });
-            receivedOffsets.clear();
-
-            var secondDisposable = subscribeAndAssign.apply(secondSubscription);
-            await.untilAsserted(() -> {
-                try {
-                    assertThat(receivedOffsets).hasEntrySatisfying(firstSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
-                    assertThat(receivedOffsets).doesNotContainKey(secondSubscription);
-                } catch (Throwable e) {
-                    lastOffsets.putAll(publishToEveryPartition());
-                    throw e;
-                }
-            });
-            receivedOffsets.clear();
-
-            firstDisposable.dispose();
-            await.untilAsserted(() -> {
-                try {
-                    assertThat(receivedOffsets).doesNotContainKey(firstSubscription);
-                    assertThat(receivedOffsets).hasEntrySatisfying(secondSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
-                } catch (Throwable e) {
-                    lastOffsets.putAll(publishToEveryPartition());
-                    throw e;
-                }
-            });
-            receivedOffsets.clear();
-
-            subscribeAndAssign.apply(firstSubscription);
-            secondDisposable.dispose();
-            await.untilAsserted(() -> {
-                try {
-                    assertThat(receivedOffsets).hasEntrySatisfying(firstSubscription, it -> assertThat(it).isEqualTo(lastOffsets));
-                    assertThat(receivedOffsets).doesNotContainKey(secondSubscription);
-                } catch (Throwable e) {
-                    lastOffsets.putAll(publishToEveryPartition());
-                    throw e;
-                }
-            });
-        } finally {
-            disposeAll.onNext(true);
-        }
     }
 
     @Test

--- a/tck/src/main/java/com/github/bsideup/liiklus/records/tests/SubscribeTest.java
+++ b/tck/src/main/java/com/github/bsideup/liiklus/records/tests/SubscribeTest.java
@@ -7,7 +7,12 @@ import reactor.core.publisher.DirectProcessor;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -142,6 +147,27 @@ public interface SubscribeTest extends RecordStorageTestSupport {
                 .isNotNull()
                 .satisfies(it -> {
                     assertThat(it.getOffset()).isEqualTo(offsetInfo.getOffset());
+                });
+    }
+
+    @Test
+    default void testValidTimestamp() throws Exception {
+        var topic = getTopic();
+        var offsetInfo = publish(new RecordsStorage.Envelope(
+                topic,
+                null,
+                ByteBuffer.wrap("hello".getBytes())
+        ));
+        int partition = offsetInfo.getPartition();
+
+        var record = subscribeToPartition(partition)
+                .flatMap(RecordsStorage.PartitionSource::getPublisher)
+                .blockFirst(Duration.ofSeconds(10));
+
+        assertThat(record)
+                .isNotNull()
+                .satisfies(it -> {
+                    assertThat(it.getTimestamp()).isAfter(Instant.ofEpochMilli(0));
                 });
     }
 }

--- a/tck/src/main/java/com/github/bsideup/liiklus/records/tests/SubscribeTest.java
+++ b/tck/src/main/java/com/github/bsideup/liiklus/records/tests/SubscribeTest.java
@@ -8,11 +8,7 @@ import reactor.core.publisher.DirectProcessor;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 


### PR DESCRIPTION
There are a few bugs currently to fix in order to run pulsar with liiklus:
- Flux.when for pulsar consumer creation have a bug which creates too much consumers without proper resource cleanup, this is fixed in #174 , this also take some code from there
- Pulsar client does not automatically reconnect, and hence skipping AlreadyClosedException will cause the connection to be stuck, and also adding retry so that a new consumer can be re-created if the pulsar client consumer is for some reason disconnected
- Reset subscription is always failing if the consumer is lagging because the offset for reset subscription will refer to closed or old ledger, and pulsar treat entryId check for these ledgers differently than the latest ledger (it's minus 1 entry id)
- Failover subscription mode gets stuck if the consuming consumer is disconnected. Currently, liiklus connects to all partitions, and the balancing of consumer per partition happens on the record storage client side. However, if there are two pulsar consumer clients on failover mode for one subscription, and the consuming client is disconnected, the other client does not get any message. This might be due to the manual reset of the subscription offset (because pulsar server disconnect all consumers of a subscription on a reset/seek offset). Hence, switching to exclusive subscription type so that liiklus can handle the rebalancing properly. This model is closed to Reader interface of pulsar, which is made for manual offset management. However pulsar reader interface itself can't be used since it does not allow exclusive reading of a partition.
- Currently the pulsar records storage is taking only event timestamp, however event timestamp does not always exist, and it should fall back to publish timestamp. Otherwise the liiklus client will see 1970-01-01 as timestamp.