### PR TITLE
expect always earliest offset on empty initial offset for the records

### DIFF
--- a/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
+++ b/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
@@ -11,6 +11,7 @@ import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.Murmur3_32Hash;
 import org.apache.pulsar.client.util.MathUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.testcontainers.containers.PulsarContainer;
@@ -77,6 +78,12 @@ public class PulsarRecordsStorageTest implements RecordStorageTests {
     @Override
     public int getNumberOfPartitions() {
         return NUM_OF_PARTITIONS;
+    }
+
+    @Override
+    @Test
+    @Disabled("#180 - Pulsar should fix the way seek works, not disconnecting consumers (apache/pulsar/pull/5022)")
+    public void shouldAlwaysUseEarliestOffsetOnEmptyOffsetsInTheInitialProvider() {
     }
 
     @Test

--- a/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
+++ b/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorageTest.java
@@ -11,20 +11,30 @@ import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.Murmur3_32Hash;
 import org.apache.pulsar.client.util.MathUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.context.ApplicationContext;
 import org.testcontainers.containers.PulsarContainer;
 import reactor.core.publisher.Mono;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
 public class PulsarRecordsStorageTest implements RecordStorageTests {
 
@@ -82,7 +92,7 @@ public class PulsarRecordsStorageTest implements RecordStorageTests {
 
     @Override
     @Test
-    @Disabled("#180 - Pulsar should fix the way seek works, not disconnecting consumers (apache/pulsar/pull/5022)")
+    @DisabledUntil(value = "2020-01-01", comment = "#180 - Pulsar should fix the way seek works, not disconnecting consumers (apache/pulsar/pull/5022)")
     public void shouldAlwaysUseEarliestOffsetOnEmptyOffsetsInTheInitialProvider() {
     }
 
@@ -93,7 +103,7 @@ public class PulsarRecordsStorageTest implements RecordStorageTests {
         var key = keyByPartition(partition);
         var eventTimestamp = Instant.now().minusSeconds(1000).truncatedTo(ChronoUnit.MILLIS);
 
-        try(
+        try (
                 var pulsarClient = PulsarClient.builder()
                         .serviceUrl(pulsar.getPulsarBrokerUrl())
                         .build()
@@ -117,4 +127,36 @@ public class PulsarRecordsStorageTest implements RecordStorageTests {
             assertThat(it.getTimestamp()).isEqualTo(eventTimestamp);
         });
     }
+
+
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @ExtendWith(DisabledUntil.DisabledCondition.class)
+    public @interface DisabledUntil {
+        String value();
+
+        String comment();
+
+        class DisabledCondition implements ExecutionCondition {
+
+            @Override
+            public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+                Optional<DisabledUntil> until = findAnnotation(context.getElement(), DisabledUntil.class);
+                if (until.isPresent()
+                        && until.map(DisabledUntil::value)
+                        .map(date -> LocalDate.parse(date).isAfter(LocalDate.now()))
+                        .orElse(false)
+                ) {
+                    String reason = until.map(DisabledUntil::comment).orElse("Disabled for now");
+                    return ConditionEvaluationResult.disabled(reason);
+                }
+
+                return ConditionEvaluationResult.enabled("Enabled");
+            }
+
+        }
+
+    }
+
+
 }

--- a/tck/src/main/java/com/github/bsideup/liiklus/support/DisabledUntil.java
+++ b/tck/src/main/java/com/github/bsideup/liiklus/support/DisabledUntil.java
@@ -1,0 +1,42 @@
+package com.github.bsideup.liiklus.support;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledUntil.DisabledCondition.class)
+public @interface DisabledUntil {
+    /**
+     * Local date, ISO formatted string such as 2000-01-30
+     */
+    String value();
+
+    String comment();
+
+    class DisabledCondition implements ExecutionCondition {
+
+        @Override
+        public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+            Optional<DisabledUntil> until = findAnnotation(context.getElement(), DisabledUntil.class);
+            if (until.map(it -> LocalDate.parse(it.value()).isAfter(LocalDate.now())).orElse(false)) {
+                String reason = until.map(DisabledUntil::comment).orElse("Disabled for now");
+                return ConditionEvaluationResult.disabled(reason);
+            }
+
+            return ConditionEvaluationResult.enabled("Enabled");
+        }
+    }
+}


### PR DESCRIPTION
Pulsar by default caches the result of the seek, so in case you do seek,
then create new subscription with the same group name without seek and
`earliest` subscription type, it will get back to the last seeked offset
what is different from the Kafka and should be aligned in the liiklus