### PR TITLE
Disable group ack for the consumer

### DIFF
--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -187,6 +188,7 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
             return Flux.usingWhen(
                     Mono.fromCompletionStage(() -> {
                         val consumerBuilder = pulsarClient.newConsumer()
+                                .acknowledgmentGroupTime(0, TimeUnit.SECONDS) // we don't ack here at all
                                 .subscriptionName(groupName)
                                 .subscriptionType(SubscriptionType.Failover)
                                 .topic(TopicName.get(topic).getPartition(partition).toString());


### PR DESCRIPTION
We actually don't need ack capabilities here at all, so better
to disable the scheduling of the grouped ack flush to avoid any leaks
and useless objects creation.

Cleanup issues should be fixed here
https://github.com/apache/pulsar/pull/5204