### PR TITLE
Pluggable customizers for GRPC transport via configurer beans

### DIFF
--- a/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/GRPCLiiklusTransportConfigurer.java
+++ b/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/GRPCLiiklusTransportConfigurer.java
@@ -1,0 +1,8 @@
+package com.github.bsideup.liiklus.transport.grpc;
+
+import io.grpc.netty.NettyServerBuilder;
+
+@FunctionalInterface
+public interface GRPCLiiklusTransportConfigurer {
+    void apply(NettyServerBuilder builder);
+}

--- a/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfiguration.java
+++ b/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfiguration.java
@@ -12,6 +12,7 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Profiles;
 
 import javax.validation.constraints.Min;
@@ -20,7 +21,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @AutoService(ApplicationContextInitializer.class)
+@Order(GRPCConfiguration.GRPC_CONFIGURATION_ORDER)
 public class GRPCConfiguration implements ApplicationContextInitializer<GenericApplicationContext> {
+
+    public static final int GRPC_CONFIGURATION_ORDER = 0;
 
     @Override
     public void initialize(GenericApplicationContext applicationContext) {
@@ -59,6 +63,10 @@ public class GRPCConfiguration implements ApplicationContextInitializer<GenericA
                         serverBuilder.addService(bindableService);
                     }
 
+                    for (var transportConfigurer : applicationContext.getBeansOfType(GRPCTransportConfigurer.class).values()) {
+                        transportConfigurer.apply(serverBuilder);
+                    }
+
                     return serverBuilder.build();
                 },
                 it -> {
@@ -93,6 +101,11 @@ public class GRPCConfiguration implements ApplicationContextInitializer<GenericA
             }
         }
 
+    }
+
+    @FunctionalInterface
+    public interface GRPCTransportConfigurer {
+        void apply(NettyServerBuilder builder);
     }
 
 }

--- a/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfiguration.java
+++ b/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfiguration.java
@@ -1,6 +1,7 @@
 package com.github.bsideup.liiklus.transport.grpc.config;
 
 import com.github.bsideup.liiklus.transport.grpc.GRPCLiiklusService;
+import com.github.bsideup.liiklus.transport.grpc.GRPCLiiklusTransportConfigurer;
 import com.github.bsideup.liiklus.util.PropertiesUtil;
 import com.google.auto.service.AutoService;
 import io.grpc.*;
@@ -59,7 +60,7 @@ public class GRPCConfiguration implements ApplicationContextInitializer<GenericA
                         serverBuilder.addService(bindableService);
                     }
 
-                    for (var transportConfigurer : applicationContext.getBeansOfType(GRPCTransportConfigurer.class).values()) {
+                    for (var transportConfigurer : applicationContext.getBeansOfType(GRPCLiiklusTransportConfigurer.class).values()) {
                         transportConfigurer.apply(serverBuilder);
                     }
 
@@ -97,11 +98,6 @@ public class GRPCConfiguration implements ApplicationContextInitializer<GenericA
             }
         }
 
-    }
-
-    @FunctionalInterface
-    public interface GRPCTransportConfigurer {
-        void apply(NettyServerBuilder builder);
     }
 
 }

--- a/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfiguration.java
+++ b/plugins/grpc-transport/src/main/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfiguration.java
@@ -12,7 +12,6 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Profiles;
 
 import javax.validation.constraints.Min;
@@ -21,10 +20,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @AutoService(ApplicationContextInitializer.class)
-@Order(GRPCConfiguration.GRPC_CONFIGURATION_ORDER)
 public class GRPCConfiguration implements ApplicationContextInitializer<GenericApplicationContext> {
-
-    public static final int GRPC_CONFIGURATION_ORDER = 0;
 
     @Override
     public void initialize(GenericApplicationContext applicationContext) {

--- a/plugins/grpc-transport/src/test/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfigurationTest.java
+++ b/plugins/grpc-transport/src/test/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfigurationTest.java
@@ -89,8 +89,6 @@ class GRPCConfigurationTest {
                     context.registerBean(GRPCLiiklusTransportConfigurer.class, () -> builder -> builder.addService(() -> service));
                 })
                 .run(context -> {
-                    assertThat(context).hasNotFailed();
-                    assertThat(context).getBeans(GRPCLiiklusService.class).isNotEmpty();
                     assertThat(context).getBeans(GRPCLiiklusTransportConfigurer.class).isNotEmpty();
 
                     assertThat(context)

--- a/plugins/grpc-transport/src/test/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfigurationTest.java
+++ b/plugins/grpc-transport/src/test/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfigurationTest.java
@@ -89,10 +89,9 @@ class GRPCConfigurationTest {
                     context.registerBean(GRPCLiiklusTransportConfigurer.class, () -> builder -> builder.addService(() -> service));
                 })
                 .run(context -> {
-                    assertThat(context)
-                            .hasNotFailed()
-                            .hasSingleBean(GRPCLiiklusService.class)
-                            .getBeans(GRPCLiiklusTransportConfigurer.class).isNotEmpty();
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).getBeans(GRPCLiiklusService.class).isNotEmpty();
+                    assertThat(context).getBeans(GRPCLiiklusTransportConfigurer.class).isNotEmpty();
 
                     assertThat(context)
                             .getBean(Server.class)

--- a/plugins/grpc-transport/src/test/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfigurationTest.java
+++ b/plugins/grpc-transport/src/test/java/com/github/bsideup/liiklus/transport/grpc/config/GRPCConfigurationTest.java
@@ -92,7 +92,7 @@ class GRPCConfigurationTest {
                     assertThat(context)
                             .hasNotFailed()
                             .hasSingleBean(GRPCLiiklusService.class)
-                            .hasSingleBean(GRPCLiiklusTransportConfigurer.class);
+                            .getBeans(GRPCLiiklusTransportConfigurer.class).isNotEmpty();
 
                     assertThat(context)
                             .getBean(Server.class)


### PR DESCRIPTION
This PR just opens the way on more lightweight plugins to add something for the GRPC transport. E.g. auth. 

The approach is quite simple, so if it's fine, I'll add some tests.