### PR TITLE
Don't generate random names to read end offsets in subscription

### DIFF
--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -5,6 +5,8 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImplAccessor;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
@@ -17,7 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -28,6 +29,8 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PulsarRecordsStorage implements FiniteRecordsStorage {
+
+    private static final String LIIKLUS_END_OFFSETS_READER_SUBSCRIPTION_NAME = "liiklus-end-offsets-reader";
 
     public static MessageId fromOffset(long offset) {
         return new MessageIdImpl(offset >>> 28, offset & 0x0F_FF_FF_FFL, -1);
@@ -102,7 +105,7 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
                     var partitionIndex = TopicName.getPartitionIndex(partitionTopic);
 
                     var consumerFuture = pulsarClient.newConsumer()
-                            .subscriptionName(UUID.randomUUID().toString())
+                            .subscriptionName(LIIKLUS_END_OFFSETS_READER_SUBSCRIPTION_NAME)
                             .subscriptionType(SubscriptionType.Failover)
                             .topic(partitionTopic)
                             .subscribeAsync();

--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -5,8 +5,6 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImplAccessor;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
@@ -30,7 +28,7 @@ import java.util.stream.Stream;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PulsarRecordsStorage implements FiniteRecordsStorage {
 
-    private static final String LIIKLUS_END_OFFSETS_READER_SUBSCRIPTION_NAME = "liiklus-end-offsets-reader";
+    private static final String SUBSCRIPTION_NAME = "liiklus-end-offsets-reader";
 
     public static MessageId fromOffset(long offset) {
         return new MessageIdImpl(offset >>> 28, offset & 0x0F_FF_FF_FFL, -1);
@@ -105,7 +103,7 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
                     var partitionIndex = TopicName.getPartitionIndex(partitionTopic);
 
                     var consumerFuture = pulsarClient.newConsumer()
-                            .subscriptionName(LIIKLUS_END_OFFSETS_READER_SUBSCRIPTION_NAME)
+                            .subscriptionName(SUBSCRIPTION_NAME)
                             .subscriptionType(SubscriptionType.Failover)
                             .topic(partitionTopic)
                             .subscribeAsync();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1964214/74443882-3f190a80-4e74-11ea-9e78-235d96ce2470.png)

simple query from pulsar via prometheus `sum(pulsar_subscription_msg_throughput_out) by (subscription)` gives this weird picture. I have to manually cleanup all of those subscriptions after each end offsets call