### PR TITLE
Simplify the consumer grp test to contain less branches

### DIFF
--- a/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/AbstractPulsarRecordsStorageTest.java
+++ b/plugins/pulsar-records-storage/src/test/java/com/github/bsideup/liiklus/pulsar/AbstractPulsarRecordsStorageTest.java
@@ -41,7 +41,7 @@ abstract class AbstractPulsarRecordsStorageTest implements RecordStorageTests {
 
     @Override
     @Test
-    @DisabledUntil(value = "2020-05-01", comment = "#180 - Pulsar should fix the way seek works, not disconnecting consumers (apache/pulsar/pull/5022)")
+    @DisabledUntil(value = "2020-06-01", comment = "#180 - Pulsar should fix the way seek works, not disconnecting consumers (apache/pulsar/pull/5022)")
     public void shouldAlwaysUseEarliestOffsetOnEmptyOffsetsInTheInitialProvider() {
         RecordStorageTests.super.shouldAlwaysUseEarliestOffsetOnEmptyOffsetsInTheInitialProvider();
     }

--- a/tck/src/main/java/com/github/bsideup/liiklus/records/tests/ConsumerGroupTest.java
+++ b/tck/src/main/java/com/github/bsideup/liiklus/records/tests/ConsumerGroupTest.java
@@ -86,8 +86,10 @@ public interface ConsumerGroupTest extends RecordStorageTestSupport {
             var lastOffsets = new HashMap<Integer, Long>();
 
             var firstDisposable = subscribeAndAssign.apply(firstSubscription);
+            var publishMessagesOnFail = onFailedCondition(() -> lastOffsets.putAll(publishToEveryPartition()));
+
             await
-                    .conditionEvaluationListener(onFailedCondition(() -> lastOffsets.putAll(publishToEveryPartition())))
+                    .conditionEvaluationListener(publishMessagesOnFail)
                     .untilAsserted(() -> {
                         assertThat(receivedOffsets)
                                 .hasSize(1)
@@ -98,7 +100,7 @@ public interface ConsumerGroupTest extends RecordStorageTestSupport {
 
             var secondDisposable = subscribeAndAssign.apply(secondSubscription);
             await
-                    .conditionEvaluationListener(onFailedCondition(() -> lastOffsets.putAll(publishToEveryPartition())))
+                    .conditionEvaluationListener(publishMessagesOnFail)
                     .untilAsserted(() -> {
                         assertThat(receivedOffsets)
                                 .hasSize(2)
@@ -109,7 +111,7 @@ public interface ConsumerGroupTest extends RecordStorageTestSupport {
 
             secondDisposable.dispose();
             await
-                    .conditionEvaluationListener(onFailedCondition(() -> lastOffsets.putAll(publishToEveryPartition())))
+                    .conditionEvaluationListener(publishMessagesOnFail)
                     .untilAsserted(() -> {
                         assertThat(receivedOffsets)
                                 .hasSize(1)
@@ -121,7 +123,7 @@ public interface ConsumerGroupTest extends RecordStorageTestSupport {
             subscribeAndAssign.apply(secondSubscription);
             firstDisposable.dispose();
             await
-                    .conditionEvaluationListener(onFailedCondition(() -> lastOffsets.putAll(publishToEveryPartition())))
+                    .conditionEvaluationListener(publishMessagesOnFail)
                     .untilAsserted(() -> {
                         assertThat(receivedOffsets)
                                 .hasSize(1)


### PR DESCRIPTION
Otherwise I always have hard times to follow the test flow without debug
Also it seems that test is named slightly incorrect, as it's one grp
but multiple consumers. Maybe not the best name for now, but hopefully better
than incorrect