### PR TITLE
unsubscribe pulsar consumer before closing

### DIFF
--- a/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
+++ b/plugins/pulsar-records-storage/src/main/java/com/github/bsideup/liiklus/pulsar/PulsarRecordsStorage.java
@@ -251,7 +251,8 @@ public class PulsarRecordsStorage implements FiniteRecordsStorage {
                                         })
                                 );
                     },
-                    consumer -> Mono.fromCompletionStage(consumer.closeAsync())
+                    consumer -> Mono.fromCompletionStage(consumer::unsubscribeAsync)
+                            .then(Mono.fromCompletionStage(consumer::closeAsync))
             );
         }
     }


### PR DESCRIPTION
That way it won't produce "Consumer is already closed" exception in the receive
flow which end up as `Operator called default onErrorDropped - org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: Consumer is already closed`

in the logs. That happens cause first general flow cancelled, while receive is still there. So when receive flow is cancelled, consumer is already closed.
Forcing client to unsubscribe will ensure receive flow wouldn't be there at the moment of the general flow cancellation.

This change could be considered as cosmetic, so its hard to test without massive code. But could be reproduced with the client disconnection in the logs relatively easy.