### PR TITLE
Constant name for the app-boot.jar in app module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ jar {
 
 bootJar {
     archiveClassifier = 'boot'
+    archiveVersion = ''
 }
 
 dependencies {

--- a/tck/build.gradle
+++ b/tck/build.gradle
@@ -23,17 +23,27 @@ tasks.test.dependsOn(
         rootProject.project(":plugins:inmemory-records-storage").getTasksByName("jar", false)
 )
 
-processResources {
+tasks.register('appDependency') {
     dependsOn(
             tasks.findByPath(":app:sourcesJar"),
             tasks.findByPath(":app:bootJar"),
             tasks.findByPath(":app:jar")
     )
+
+    doLast {
+        def app = tasks.findByPath(":app:bootJar").outputs.files.singleFile
+        if (app.name != 'app-boot.jar') {
+            throw new GradleException(':app:bootJar task should produce explicitly "app-boot.jar" file to be included into TCK, got: ' + app.absolutePath)
+        }
+    }
 }
+
+processResources.dependsOn(tasks.appDependency)
 
 sourceSets {
     main {
         resources.srcDir tasks.findByPath(":app:bootJar").outputs.files.singleFile.parentFile
+        resources.include 'app-boot.jar'
     }
 }
 

--- a/tck/build.gradle
+++ b/tck/build.gradle
@@ -33,7 +33,7 @@ tasks.register('appDependency') {
     doLast {
         def app = tasks.findByPath(":app:bootJar").outputs.files.singleFile
         if (app.name != 'app-boot.jar') {
-            throw new GradleException(':app:bootJar task should produce explicitly "app-boot.jar" file to be included into TCK, got: ' + app.absolutePath)
+            throw new GradleException(':app:bootJar task should produce exactly "app-boot.jar" file to be included into TCK, got: ' + app.absolutePath)
         }
     }
 }


### PR DESCRIPTION
On jitpack version got added into jar file produced by the app module - so that it looks like `app-0.10.1-rc1-boot.jar`.
Obviously, tck during the search of the resource `app-boot.jar` fails to find anything with a NPE, 
what makes tck app runner unusable outside of the original repo. Also currently, all jars embedded into tck, 
however we need only a boot one (among sources and bare minimum ones), so this PR fixes that as well.