### PR TITLE
Implement JUnit5 extension points for application runner

### DIFF
--- a/plugins/grpc-transport-auth/src/test/java/com/github/bsideup/liiklus/transport/grpc/GRPCAuthTest.java
+++ b/plugins/grpc-transport-auth/src/test/java/com/github/bsideup/liiklus/transport/grpc/GRPCAuthTest.java
@@ -17,9 +17,12 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Server;
 import io.grpc.StatusRuntimeException;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.pf4j.PluginManager;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -58,125 +61,7 @@ class GRPCAuthTest {
         return (int) getPortMethod.invoke(server);
     }
 
-
-    @Test
-    void shouldPublishOnlyWithAuthHmac512() {
-        var event = PublishRequest.newBuilder()
-                .setTopic("authorized")
-                .setLiiklusEvent(LIIKLUS_EVENT_EXAMPLE)
-                .build();
-
-        try (var app = new ApplicationRunner("MEMORY", "MEMORY")
-                .withProperty("grpc.enabled", true)
-                .withProperty("grpc.port", 0)
-                .withProperty("grpc.auth.alg", "HMAC512")
-                .withProperty("grpc.auth.secret", "secret")
-                .run()
-        ) {
-            int port = getGRPCPort(app);
-
-            var unauthClient = new GRPCLiiklusClient(
-                    ManagedChannelBuilder
-                            .forAddress("localhost", port)
-                            .directExecutor()
-                            .usePlaintext()
-                            .build()
-            );
-
-            assertThatThrownBy(() -> unauthClient.publish(event).block())
-                    .isInstanceOf(StatusRuntimeException.class)
-                    .hasMessageContaining("UNAUTHENTICATED: authorization header not found");
-
-
-            var wrongAuthClient = new GRPCLiiklusClient(
-                    ManagedChannelBuilder
-                            .forAddress("localhost", port)
-                            .directExecutor()
-                            .usePlaintext()
-                            .intercept(authInterceptor(Algorithm.HMAC256("wrong")))
-                            .build()
-            );
-
-            assertThatThrownBy(() -> wrongAuthClient.publish(event).block())
-                    .isInstanceOf(StatusRuntimeException.class)
-                    .hasMessageContaining("UNAUTHENTICATED: authorization header validation failed: The provided Algorithm doesn't match the one defined in the JWT's Header");
-
-
-            var authenticatedClient = new GRPCLiiklusClient(
-                    ManagedChannelBuilder
-                            .forAddress("localhost", port)
-                            .directExecutor()
-                            .usePlaintext()
-                            .intercept(authInterceptor(Algorithm.HMAC512("secret")))
-                            .build()
-            );
-
-            authenticatedClient.publish(event).block();
-        }
-    }
-
-    @Test
-    void shouldPublishWithAuthRsa512() {
-        var event = PublishRequest.newBuilder()
-                .setTopic("authorized")
-                .setLiiklusEvent(LIIKLUS_EVENT_EXAMPLE)
-                .build();
-
-        try (var app = new ApplicationRunner("MEMORY", "MEMORY")
-                .withProperty("grpc.enabled", true)
-                .withProperty("grpc.port", 0)
-                .withProperty("grpc.auth.alg", "RSA512")
-                .withProperty("grpc.auth.keys.main", "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6b/6nQLIQQ8fHT4PcSyb" +
-                        "hOLUE/237dgicbjsE7/Z/uPffuc36NTMJ122ppz6dWYnCrQ6CeTgAde4hlLE7Kvv" +
-                        "aFiUbe5XKwSL8KV292XqrwRZhMI58TTTygcrBodYGzHy0Yytv703rz+9Qt5HO5BF" +
-                        "02/+sM+Z0wlH6aXl3K3/2HfSOfitqnArBGaAs+PRNX2jlVKD1c9Cb7vo5L0X7q+6" +
-                        "55uBErEoN7IHbj1u33qI/xEvPSycIiT2RXMGZkvDZH6mTsALel4aP4Qpp1NcE+kD" +
-                        "itoBYAPTGgR4gBQveXZmD10yUVgJl2icINY3FvT9oJB6wgCY9+iTvufPppT1RPFH" +
-                        "dQIDAQAB")
-                .run()
-        ) {
-            int port = getGRPCPort(app);
-
-            var authenticatedClient = new GRPCLiiklusClient(
-                    ManagedChannelBuilder
-                            .forAddress("localhost", port)
-                            .directExecutor()
-                            .usePlaintext()
-                            .intercept(authInterceptor(Algorithm.RSA512(new RSAKeyProvider() {
-                                @Override
-                                public RSAPublicKey getPublicKeyById(String keyId) {
-                                    return null; // not verifying
-                                }
-
-                                @SneakyThrows
-                                @Override
-                                public RSAPrivateKey getPrivateKey() {
-                                    // you can convert openssh key format to a rsa with `ssh-keygen -p -m PEM -f private_openssh_key`
-                                    // and then from the rsa to a pkcs8 by `openssl pkcs8 -topk8 -nocrypt -in private_openssh_key`
-                                    String privateKeyContent = new String(Files.readAllBytes(Paths.get(
-                                            ClassLoader.getSystemResource("keys/private_key_main_2048_pkcs8.pem").toURI()
-                                    )))
-                                            .replaceAll("\\n", "")
-                                            .replace("-----BEGIN PRIVATE KEY-----", "")
-                                            .replace("-----END PRIVATE KEY-----", "");
-
-                                    var keySpecPKCS8 = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyContent));
-                                    return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(keySpecPKCS8);
-                                }
-
-                                @Override
-                                public String getPrivateKeyId() {
-                                    return "main"; // matches with grpc.auth.keys -> ["main"]
-                                }
-                            })))
-                            .build()
-            );
-
-            authenticatedClient.publish(event).block();
-        }
-    }
-
-    private ClientInterceptor authInterceptor(Algorithm alg) {
+    private static ClientInterceptor authInterceptor(Algorithm alg) {
         return new ClientInterceptor() {
             @Override
             public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> call, CallOptions headers, Channel next) {
@@ -186,5 +71,132 @@ class GRPCAuthTest {
                 )));
             }
         };
+    }
+
+
+    @Nested
+    class Hmac512 {
+
+        private final PublishRequest event = PublishRequest.newBuilder()
+                .setTopic("authorized")
+                .setLiiklusEvent(LIIKLUS_EVENT_EXAMPLE)
+                .build();
+
+        @RegisterExtension
+        ApplicationRunner app = new ApplicationRunner("MEMORY", "MEMORY")
+                .withProperty("grpc.enabled", true)
+                .withProperty("grpc.port", 0)
+                .withProperty("grpc.auth.alg", "HMAC512")
+                .withProperty("grpc.auth.secret", "secret");
+
+        @Test
+        void shouldNotPublishOnlyWithoutAuth(ConfigurableApplicationContext ctx) {
+            int port = getGRPCPort(ctx);
+
+            var plain = ManagedChannelBuilder
+                    .forAddress("localhost", port)
+                    .directExecutor()
+                    .usePlaintext()
+                    .build();
+
+            assertThatThrownBy(() -> new GRPCLiiklusClient(plain).publish(event).block())
+                    .isInstanceOf(StatusRuntimeException.class)
+                    .hasMessageContaining("UNAUTHENTICATED: authorization header not found");
+        }
+
+        @Test
+        void shouldNotPublishWithWrongAuth(ConfigurableApplicationContext ctx) {
+            int port = getGRPCPort(ctx);
+
+            var wrongAuth = ManagedChannelBuilder
+                    .forAddress("localhost", port)
+                    .directExecutor()
+                    .usePlaintext()
+                    .intercept(authInterceptor(Algorithm.HMAC256("wrong")))
+                    .build();
+
+            assertThatThrownBy(() -> new GRPCLiiklusClient(wrongAuth).publish(event).block())
+                    .isInstanceOf(StatusRuntimeException.class)
+                    .hasMessageContaining("UNAUTHENTICATED: authorization header validation failed: The provided Algorithm doesn't match the one defined in the JWT's Header");
+
+        }
+
+        @Test
+        void shouldPublishOnlyWithAuthHmac512(ConfigurableApplicationContext ctx) {
+            int port = getGRPCPort(ctx);
+
+            var authenticated = ManagedChannelBuilder
+                    .forAddress("localhost", port)
+                    .directExecutor()
+                    .usePlaintext()
+                    .intercept(authInterceptor(Algorithm.HMAC512("secret")))
+                    .build();
+
+            new GRPCLiiklusClient(authenticated).publish(event).block();
+        }
+    }
+
+
+    @Nested
+    class RSA512 {
+
+        private final PublishRequest event = PublishRequest.newBuilder()
+                .setTopic("authorized")
+                .setLiiklusEvent(LIIKLUS_EVENT_EXAMPLE)
+                .build();
+
+
+        @RegisterExtension
+        ApplicationRunner app = new ApplicationRunner("MEMORY", "MEMORY")
+                .withProperty("grpc.enabled", true)
+                .withProperty("grpc.port", 0)
+                .withProperty("grpc.auth.alg", "RSA512")
+                .withProperty("grpc.auth.keys.main", "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6b/6nQLIQQ8fHT4PcSyb" +
+                        "hOLUE/237dgicbjsE7/Z/uPffuc36NTMJ122ppz6dWYnCrQ6CeTgAde4hlLE7Kvv" +
+                        "aFiUbe5XKwSL8KV292XqrwRZhMI58TTTygcrBodYGzHy0Yytv703rz+9Qt5HO5BF" +
+                        "02/+sM+Z0wlH6aXl3K3/2HfSOfitqnArBGaAs+PRNX2jlVKD1c9Cb7vo5L0X7q+6" +
+                        "55uBErEoN7IHbj1u33qI/xEvPSycIiT2RXMGZkvDZH6mTsALel4aP4Qpp1NcE+kD" +
+                        "itoBYAPTGgR4gBQveXZmD10yUVgJl2icINY3FvT9oJB6wgCY9+iTvufPppT1RPFH" +
+                        "dQIDAQAB");
+
+        @Test
+        void shouldPublishWithAuthRsa512(ConfigurableApplicationContext ctx) {
+            int port = getGRPCPort(ctx);
+
+            var authenticated = ManagedChannelBuilder
+                    .forAddress("localhost", port)
+                    .directExecutor()
+                    .usePlaintext()
+                    .intercept(authInterceptor(Algorithm.RSA512(new RSAKeyProvider() {
+                        @Override
+                        public RSAPublicKey getPublicKeyById(String keyId) {
+                            return null; // not verifying
+                        }
+
+                        @SneakyThrows
+                        @Override
+                        public RSAPrivateKey getPrivateKey() {
+                            // you can convert openssh key format to a rsa with `ssh-keygen -p -m PEM -f private_openssh_key`
+                            // and then from the rsa to a pkcs8 by `openssl pkcs8 -topk8 -nocrypt -in private_openssh_key`
+                            String privateKeyContent = new String(Files.readAllBytes(Paths.get(
+                                    ClassLoader.getSystemResource("keys/private_key_main_2048_pkcs8.pem").toURI()
+                            )))
+                                    .replaceAll("\\n", "")
+                                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                                    .replace("-----END PRIVATE KEY-----", "");
+
+                            var keySpecPKCS8 = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyContent));
+                            return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(keySpecPKCS8);
+                        }
+
+                        @Override
+                        public String getPrivateKeyId() {
+                            return "main"; // matches with grpc.auth.keys -> ["main"]
+                        }
+                    })))
+                    .build();
+
+            new GRPCLiiklusClient(authenticated).publish(event).block();
+        }
     }
 }

--- a/tck/src/test/java/com/github/bsideup/liiklus/ApplicationRunnerTest.java
+++ b/tck/src/test/java/com/github/bsideup/liiklus/ApplicationRunnerTest.java
@@ -1,16 +1,33 @@
 package com.github.bsideup.liiklus;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ApplicationRunnerTest {
 
-    @Test
-    void shouldStart() {
-        var context = new ApplicationRunner("MEMORY", "MEMORY").run();
-
-        assertThat(context).isNotNull();
+    @Nested
+    class DirectLaunch {
+        @Test
+        void shouldStart() {
+            try (var context = new ApplicationRunner("MEMORY", "MEMORY").run()) {
+                assertThat(context).isNotNull();
+            }
+        }
     }
 
+
+    @Nested
+    class ExtensionLaunch {
+        @RegisterExtension
+        ApplicationRunner app = new ApplicationRunner("MEMORY", "MEMORY");
+
+        @Test
+        void shouldStart(ConfigurableApplicationContext ctx) {
+            assertThat(ctx).isNotNull();
+        }
+    }
 }


### PR DESCRIPTION
This would open a possibility to clean test methods from try-with-resource block making them a bit cleaner, utilizing junit5 capabilities. It's still possible to use runner the old way though. 

```java

        @RegisterExtension
        ApplicationRunner app = new ApplicationRunner("MEMORY", "MEMORY")
                .withProperty("grpc.enabled", true)
                .withProperty("grpc.port", 0)
                .withProperty("grpc.auth.alg", "HMAC512")
                .withProperty("grpc.auth.secret", "secret");

```

